### PR TITLE
Build: added loader to swap REST address based in dev/prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "query-string": "^6.11.1",
     "reference-pointer": "0.0.2",
     "showdown": "^1.9.1",
+    "string-replace-loader": "^2.3.0",
     "url-parse": "^1.4.7",
     "vue": "^2.6.11",
     "vue-cookies": "^1.7.0",

--- a/src/utils/bioIndexUtils.js
+++ b/src/utils/bioIndexUtils.js
@@ -6,7 +6,7 @@
 import querystring from "query-string";
 
 // Constants
-export const BIO_INDEX_HOST = "http://18.215.38.136:5000";
+export const BIO_INDEX_HOST = "http://SERVER_IP_ADDRESS:5000";
 
 /* Perform a BioIndex query.
  */

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,6 +2,21 @@ module.exports = {
     devServer: {
         writeToDisk: true // https://webpack.js.org/configuration/dev-server/#devserverwritetodisk-
     },
+    chainWebpack: config => {
+      config.module
+      .rule('md')
+      .test(/bioIndexUtils.js$/)
+      .use("string-replace-loader")
+      .loader("string-replace-loader")
+      .options({
+              multiple: [{
+                  search: 'SERVER_IP_ADDRESS',
+                  replace:  (process.env.NODE_ENV !== 'production') ? '18.215.38.136' : '3.221.48.161',
+                  flags: 'ig'
+                }],
+       }, )
+      .end()
+    },
     configureWebpack: config => {
         if (process.env.NODE_ENV !== 'production') {
             config.devtool = 'inline-source-map';


### PR DESCRIPTION
This enables swapping a SERVER_IP_ADDRESS placeholder to another IP address based on the dev/prod environment during npm build.