### PR TITLE
pillFormatter can access labelFormatter to ensure consistent labeling

### DIFF
--- a/src/components/criterion/FilterEnumeration.vue
+++ b/src/components/criterion/FilterEnumeration.vue
@@ -48,9 +48,11 @@ export default Vue.component("filter-enumeration-control", {
         pillFormatter: {
             type: Function,
             default: (filterDefinition) =>
-                `${filterDefinition.field} = ${Formatter.capitalizedFormatter(
-                    filterDefinition.threshold
-                )}`
+                `${filterDefinition.field} = ${!!filterDefinition.labelFormatter ?
+                    filterDefinition.labelFormatter(
+                        filterDefinition.threshold
+                    )
+                : filterDefinition.threshold}`
         },
         disableSort: {
             type: Boolean,

--- a/src/components/criterion/template/FilterControlTemplate.vue
+++ b/src/components/criterion/template/FilterControlTemplate.vue
@@ -83,6 +83,10 @@ export default Vue.component("filter-control-template", {
             filterDefinition: {
                 field: this.field,
                 placeholder: this.placeholder,
+                label: this.pillFormatter,
+                pillFormatter: this.pillFormatter,
+                labelFormatter: this.labelFormatter,
+                color: this.color,
                 predicate: this.predicate,
                 multiple: !!this.multiple || !!this.splitBy ? true : false, // if undefined, default to false
                 inclusive: !!this.inclusive || !!this.splitBy ? true : false, // if undefined, default to false. split forces this to work (because a split of multiples is redundant and ambiguous if not inclusive)
@@ -96,6 +100,9 @@ export default Vue.component("filter-control-template", {
         if (!!this.filterThreshold) {
             this.updateFilter(this.filterThreshold);
         }
+    },
+    mounted() {
+        this.$parent.$parent.$emit('filter-created', this.filterDefinition);
     },
     methods: {
         validateInput(newInput) {
@@ -123,8 +130,8 @@ export default Vue.component("filter-control-template", {
                                 "change",
                                 thresholdElement.trim(),
                                 {
-                                    label: this.pillFormatter,
-                                    color: this.color,
+                                    // label: this.pillFormatter,
+                                    // color: this.color,
                                     ...this.filterDefinition,
                                 }
                             )
@@ -132,8 +139,8 @@ export default Vue.component("filter-control-template", {
                     } else {
                         // double parent since we're only using this component as a template inside of another component
                         this.$parent.$parent.$emit("change", newThreshold, {
-                            label: this.pillFormatter,
-                            color: this.color,
+                            // label: this.pillFormatter,
+                            // color: this.color,
                             ...this.filterDefinition,
                         });
                     }


### PR DESCRIPTION
The `pillFormatter` function gets the entire filter definition as an argument. The `labelFormatter` is a part of the filter definition. So it can be used in the `pillFormatter` to format the threshold's value in a pill.

This is now the default in `<filter-enumerations-control>`, where this is a common pattern of use.

Example: `mask = 1of5 1pct` becomes `mask = 5/5 + 1/5 1%` on the GAIT page since the mask picker converts the values into labels with its labelFormatter, and is an enumeration control. In this case, the pillFormatter doesn't have to be defined by the developer.

If no labelFormatter is specified, `capitalizeFormatter` from "@/utils/formatters.js" is provided by default.

