### PR TITLE
[workaround] Render intervals as split tracks by default

### DIFF
--- a/src/components/lz/beta/lzConfiguration.js
+++ b/src/components/lz/beta/lzConfiguration.js
@@ -14,6 +14,9 @@ import { applyNamespaces, mutate_attrs, query_attrs }  from "locuszoom/esm/helpe
 // getters
 // - full
 
+// FIXME: Recommend this class for total removal.
+//  This effectively wraps the LocusZoom.Layouts registry, with several custom functions that introduce major bugs while re-implementing existing functionality.
+//  It will likely need to be removed before LZjs 0.14, which will change how namespaces work
 export class LzLayout {
     layout = null;
     constructor(firstParam, secondParam, shared_name=undefined) {
@@ -64,7 +67,7 @@ export class LzLayout {
             fragile_fields.forEach(field => {
                 LocusZoom.Layouts.mutate_attrs(this.layout, correction_target(field, target_namespace), original_namespace); // since `original_namespace` was the correct value, no need to redeclare
                 LocusZoom.Layouts.mutate_attrs(this.layout, correction_target2(field, target_namespace), original_namespace); // since `original_namespace` was the correct value, no need to redeclare
-            })   
+            })
         }
 
         return this;
@@ -177,7 +180,7 @@ export class LzDataSource {
             this.name = firstParam;
         }
         if (secondParam === Object(secondParam)) {
-            // 
+            //
         }
         this.params = thirdParam;
     }

--- a/src/components/lz/panels/LocusZoomIntervalsPanel.vue
+++ b/src/components/lz/panels/LocusZoomIntervalsPanel.vue
@@ -1,5 +1,5 @@
 <script>
-
+import LocusZoom from 'locuszoom';
 import Vue from "vue";
 import LzPanel from "./LzPanel"
 import{  rgb, color } from "d3";
@@ -82,6 +82,10 @@ export function makeIntervalsPanel(
         .addFields(dataLayerQ, 'intervals', 
             ['pValue', 'fold']
         );
+    // This modifies the internal value of the portal-specific "lzLayout" abstraction.
+    // FIXME: This is a temporary, and partial, workaround to an issue where the Portal-specific LzPanelClass abstraction breaks the "split tracks" button.
+    //   Once the button is fixed it will be feasible to render annotations in collapsed mode again.
+    LocusZoom.Layouts.mutate_attrs(layout.layout, '$..data_layers[?(@.tag === "intervals")].split_tracks', true);
 
     // TODO: eliminate the translator function with field renaming!
     const translator = function (intervals) {


### PR DESCRIPTION
# Ticket
#323 

# Purpose
Render interval tracks in expanded form by default (see documentation describing [available intervals track options](https://statgen.github.io/locuszoom/docs/api/module-LocusZoom_DataLayers-intervals.html) and the [JSONPath syntax used to modify nested objects](https://statgen.github.io/locuszoom/docs/guides/interactivity.html#helper-functions-for-modifying-nested-layouts)).

This is a temporary workaround to make the page usable, but it does not address the root cause (portal-specific custom code that mangles the LZ layout).

# Limitations and followup
This is not a long term fix. It does not restore the toggle button, nor does it fix the console error. The root cause of the bug is a piece of code that should be removed in the future as part of a larger refactor. Once the code is removed, this fix can be reverted.