### PR TITLE
Fixed the bar graph on the A2F portal front page

### DIFF
--- a/src/utils/plotUtils.js
+++ b/src/utils/plotUtils.js
@@ -223,6 +223,10 @@ const renderBars = function (CTX, WIDTH, HEIGHT, MARGIN, DIRECTION, TICK_NUM, DA
     let dataKeys = Object.keys(DATA);
     let dataLength = dataKeys.length;
     let barWidth = (WIDTH - MARGIN.left - MARGIN.right - (SPACER * (dataLength + 1))) / dataLength;
+    let minBarWidth = ((WIDTH - MARGIN.left - MARGIN.right) / dataLength) - 2;
+
+    barWidth = (barWidth <= 4) ? minBarWidth : barWidth;
+
     //let valueBump = (MAX - MIN) / TICK_NUM;
     let max = Math.ceil(MAX);
     let min = Math.floor(MIN);


### PR DESCRIPTION
The bug happened when width of the plot is not wide enough for the number of the items to render.