### PR TITLE
Phenotype assoc

### DIFF
--- a/src/components/GeneFinderTable.vue
+++ b/src/components/GeneFinderTable.vue
@@ -268,6 +268,7 @@ export default Vue.component("GeneFinderTable", {
                 a.phenotypes.forEach((phenotype) => {
                     groups.push({
                         phenotype,
+                        gene: a.gene,
                         pValue: a[`${phenotype}:pValue`],
                         chromosome: a.chromosome,
                         position: Math.floor((a.start + a.end) / 2),

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -25,7 +25,6 @@ export default Vue.component("ManhattanPlot", {
     computed: {
         columns() {
             // This is getting computed many, many times. Can we reduce the number of calls?
-            console.log(JSON.stringify(this.phenotypes));
             if (this.singlePhenotype){
                 return this.columnsByGene();
             }
@@ -58,8 +57,6 @@ export default Vue.component("ManhattanPlot", {
                     if (r.phenotype == p) {
                         x.push(chromosomeStart[r.chromosome] + r.position);
                         y.push(-Math.log10(r.pValue));
-                    } else {
-                        console.log("Non-matching phenotype!!!");
                     }
                 });
 
@@ -141,7 +138,6 @@ export default Vue.component("ManhattanPlot", {
                     type: "scatter",
                     order: null,
                     color: function (color, d) {
-                        //console.log(JSON.stringify(d));
                         if (
                             !component.phenotypes ||
                             !component.colorByPhenotype ||
@@ -149,7 +145,6 @@ export default Vue.component("ManhattanPlot", {
                         ) {
                             return positionColors.find((c) => d.x < c[0])[1];
                         }
-
                         // phenotype index will determine the color
                         let i = component.phenotypes.indexOf(d.id);
 
@@ -324,7 +319,7 @@ for (let i in chromosomes) {
     opacity: 0.65 !important;
     fill: currentColor;
 }
-</script > <style > div.manhattan-tooltip table {
+div.manhattan-tooltip table {
     background-color: white;
     font-size: small;
     border: 1px solid darkgray;

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -38,7 +38,7 @@ export default Vue.component("ManhattanPlot", {
                 return { pValue: "pValue_x" };
             }
             let xs = {};
-            let allKeys = this.singlePhenotype ? this.associations.map(r => r.gene) : this.phenotypeMap;
+            let allKeys = this.singlePhenotype ? this.associations.map(r => r.gene) : this.phenotypes;
             allKeys.forEach((p) => {
                 xs[p] = `${p}_x`;
             });

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div id="manhattan" style="width: 100%; height: 300px"></div>
+        <div :id="`manhattan_${uniqueId}`" style="width: 100%; height: 300px"></div>
     </div>
 </template>
 
@@ -17,6 +17,7 @@ export default Vue.component("ManhattanPlot", {
     data() {
         return {
             chart: null,
+            uniqueId: Math.floor(Math.random() * 10e9)
         };
     },
 
@@ -101,7 +102,7 @@ export default Vue.component("ManhattanPlot", {
 
             // attach to the dom
             this.chart = c3.generate({
-                bindto: "#manhattan",
+                bindto: `#manhattan_${this.uniqueId}`,
                 size: {
                     height: 300,
                 },

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -68,34 +68,20 @@ export default Vue.component("ManhattanPlot", {
         },
         columnKeys() {
             let xs = {};
-            let phenotypeMap = this.phenotypeMap;
-
-            // if there's a list of phenotypes, each phenotype gets a color
             if (!this.phenotypes) {
                 return { pValue: "pValue_x" };
             }
-
-            this.phenotypes.forEach((p) => {
+            let allKeys = this.singlePhenotype ? this.associations.map(r => r.gene) : this.phenotypeMap;
+            allKeys.forEach((p) => {
                 xs[p] = `${p}_x`;
             });
-
             return xs;
         },
-        geneKeys(){
-            let xs = {};
-            this.associations.forEach(r => {
-                xs[r.gene] = `${r.gene}_x`;
-            });
-            return xs;
-        }
     },
 
     watch: {
         columns(data) {
-            let columns = data;
-            let xs = this.singlePhenotype ? this.geneKeys : this.columnKeys;
-
-            this.build_chart(xs, columns);
+            this.build_chart(this.columnKeys, data);
         },
     },
 

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -31,7 +31,7 @@ export default Vue.component("ManhattanPlot", {
             if (!this.phenotypes) {
                 return this.columnsNoPhenotype();
             }
-            return columnsMultiPhenotype();
+            return this.columnsMultiPhenotype();
         },
         columnKeys() {
             if (!this.phenotypes) {

--- a/src/components/ManhattanPlot.vue
+++ b/src/components/ManhattanPlot.vue
@@ -17,7 +17,8 @@ export default Vue.component("ManhattanPlot", {
     data() {
         return {
             chart: null,
-            uniqueId: Math.floor(Math.random() * 10e9)
+            uniqueId: Math.floor(Math.random() * 10e9),
+            singlePhenotype: this.phenotypes.length === 1
         };
     },
 
@@ -25,7 +26,7 @@ export default Vue.component("ManhattanPlot", {
         columns() {
             // This is getting computed many, many times. Can we reduce the number of calls?
             console.log(JSON.stringify(this.phenotypes));
-            if (this.phenotypes.length === 1){
+            if (this.singlePhenotype){
                 return this.columnsByGene();
             }
             let n = (this.associations || []).length;
@@ -95,7 +96,7 @@ export default Vue.component("ManhattanPlot", {
     watch: {
         columns(data) {
             let columns = data;
-            let xs = this.phenotypes.length !== 1 ? this.columnKeys : this.geneKeys;
+            let xs = this.singlePhenotype ? this.geneKeys : this.columnKeys;
 
             this.build_chart(xs, columns);
         },
@@ -143,7 +144,8 @@ export default Vue.component("ManhattanPlot", {
                         //console.log(JSON.stringify(d));
                         if (
                             !component.phenotypes ||
-                            !component.colorByPhenotype
+                            !component.colorByPhenotype ||
+                            component.singlePhenotype
                         ) {
                             return positionColors.find((c) => d.x < c[0])[1];
                         }

--- a/src/views/Phenotype/Template.vue
+++ b/src/views/Phenotype/Template.vue
@@ -308,16 +308,34 @@
                             </filter-pvalue-control>
 
                             <template slot="filtered" slot-scope="{ filter }">
-                                <gene-finder-table
-                                    :phenotypes="[$store.state.phenotype.name]"
-                                    :phenotype-map="
-                                        $store.state.bioPortal.phenotypeMap
-                                    "
-                                    :associations="$store.state.genes.data"
-                                    :rows-per-page="10"
-                                    :filter="filter"
-                                    :show-plot="true"
-                                ></gene-finder-table>
+                                <b-tabs>
+                                    <b-tab title="Common variant associations">
+                                        <gene-finder-table
+                                            :phenotypes="[$store.state.phenotype.name]"
+                                            :phenotype-map="
+                                                $store.state.bioPortal.phenotypeMap
+                                            "
+                                            :associations="$store.state.genes.data"
+                                            :rows-per-page="10"
+                                            :filter="filter"
+                                            :show-plot="true"
+                                        >
+                                        </gene-finder-table>
+                                    </b-tab>
+                                    <b-tab title="Testing testing testing">
+                                        <gene-finder-table
+                                            :phenotypes="[$store.state.phenotype.name]"
+                                            :phenotype-map="
+                                                $store.state.bioPortal.phenotypeMap
+                                            "
+                                            :associations="$store.state.genes52k.data"
+                                            :rows-per-page="10"
+                                            :filter="filter"
+                                            :show-plot="true"
+                                        >
+                                        </gene-finder-table>
+                                    </b-tab>
+                                </b-tabs>
                             </template>
                         </criterion-function-group>
                     </div>

--- a/src/views/Phenotype/Template.vue
+++ b/src/views/Phenotype/Template.vue
@@ -272,16 +272,9 @@
                 <div class="card mdkp-card">
                     <div class="card-body">
                         <h4 class="card-title">
-                            Top common variant gene-level associations for
+                            Top gene-level associations for
                             {{ $store.state.phenotype.description }}
-                            with P-Value &le; 0.05 (Ancestry:
-                            {{
-                                $store.state.ancestry == ""
-                                    ? "All"
-                                    : $parent.ancestryFormatter(
-                                          $store.state.ancestry
-                                      )
-                            }})
+                            with P-Value &le; 0.05
 
                             <tooltip-documentation
                                 name="phenotype.genes.tooltip"
@@ -309,7 +302,9 @@
 
                             <template slot="filtered" slot-scope="{ filter }">
                                 <b-tabs>
-                                    <b-tab title="Common variant associations">
+                                    <b-tab :title="`Common variant associations (Ancestry: 
+                                        ${$store.state.ancestry === '' ? 'All' 
+                                            : $parent.ancestryFormatter($store.state.ancestry)})`">
                                         <gene-finder-table
                                             :phenotypes="[$store.state.phenotype.name]"
                                             :phenotype-map="
@@ -322,7 +317,7 @@
                                         >
                                         </gene-finder-table>
                                     </b-tab>
-                                    <b-tab title="Testing testing testing">
+                                    <b-tab title="Rare variant associations (all ancestries)">
                                         <gene-finder-table
                                             :phenotypes="[$store.state.phenotype.name]"
                                             :phenotype-map="

--- a/src/views/Phenotype/store.js
+++ b/src/views/Phenotype/store.js
@@ -15,6 +15,7 @@ export default new Vuex.Store({
         associations: bioIndex("global-associations"),
         annotations: bioIndex("global-enrichment"),
         genes: bioIndex("gene-finder"),
+        genes52k: bioIndex("gene-finder-52k"),
         ancestryGlobalAssoc: bioIndex("ancestry-global-associations"),
         geneticCorrelation: bioIndex("genetic-correlation"),
         pathwayAssoc: bioIndex("pathway-associations")
@@ -80,6 +81,7 @@ export default new Vuex.Store({
             }
             context.dispatch("annotations/query", query);
             context.dispatch("genes/query", geneQuery);
+            context.dispatch("genes52k/query", query);
             context.dispatch("geneticCorrelation/query", ancestryOptionalQuery);
             context.dispatch("pathwayAssoc/query", ancestryOptionalQuery);
             context.state.manhattanPlotAvailable = true;

--- a/src/views/Phenotype/store.js
+++ b/src/views/Phenotype/store.js
@@ -73,6 +73,7 @@ export default new Vuex.Store({
             let ancestryAssocQuery = { ...ancestryQuery, limit: 1000 };
             let ancestryOptionalQuery = !context.state.ancestry ? query : ancestryQuery;
             let geneQuery = { ...ancestryOptionalQuery, limitWhile: r => r.pValue <= 0.05, limit: 1000 };
+            let gene52kQuery = {...query, limitWhile: r => r.pValue <=0.05, limit: 1000};
 
             if (context.state.ancestry == "" || context.state.ancestry == null) {
                 context.dispatch("associations/query", assocQuery);
@@ -81,7 +82,7 @@ export default new Vuex.Store({
             }
             context.dispatch("annotations/query", query);
             context.dispatch("genes/query", geneQuery);
-            context.dispatch("genes52k/query", query);
+            context.dispatch("genes52k/query", gene52kQuery);
             context.dispatch("geneticCorrelation/query", ancestryOptionalQuery);
             context.dispatch("pathwayAssoc/query", ancestryOptionalQuery);
             context.state.manhattanPlotAvailable = true;


### PR DESCRIPTION
First pass at adding common/rare variant association plots to the Phenotype page. Todo: add both gene and phenotype label to tooltip on hover. (Not a problem here since the phenotype page only shows one phenotype at a time. This is a preexisting issue on SignalSifter though.)