### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/src/modules/kp4cd.js
+++ b/src/modules/kp4cd.js
@@ -250,7 +250,18 @@ export default {
         async getResearchData(context, targetDataPoint) {
             // If it's a kp4cd.org URL, use fallback logic; otherwise fetch directly
             let json;
-            if (targetDataPoint && targetDataPoint.includes('kp4cd.org')) {
+            let isKp4cdHost = false;
+            if (targetDataPoint) {
+                try {
+                    const parsedUrl = new URL(targetDataPoint);
+                    const hostname = parsedUrl.hostname.toLowerCase();
+                    isKp4cdHost = hostname === "kp4cd.org" || hostname.endsWith(".kp4cd.org");
+                } catch (e) {
+                    isKp4cdHost = false;
+                }
+            }
+
+            if (isKp4cdHost) {
                 json = await fetchWithFallback(targetDataPoint);
             } else {
                 json = await fetch(targetDataPoint).then((resp) => resp.json());


### PR DESCRIPTION
Potential fix for [https://github.com/broadinstitute/dig-dug-portal/security/code-scanning/11](https://github.com/broadinstitute/dig-dug-portal/security/code-scanning/11)

Use URL parsing and exact host matching instead of substring matching.

Best fix in this file: in `getResearchData`, replace `targetDataPoint.includes('kp4cd.org')` with logic that:

1. Safely parses `targetDataPoint` via `new URL(...)`.
2. Extracts and normalizes `hostname`.
3. Checks host as `hostname === 'kp4cd.org'` or (if desired to preserve likely intent) `hostname.endsWith('.kp4cd.org')`.
4. Only then uses `fetchWithFallback`; otherwise use direct `fetch`.
5. If parsing fails, treat as non-kp4cd URL and use direct fetch (preserves existing behavior without introducing new rejection paths).

No new dependencies are required; `URL` is built-in.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
