### PR TITLE
Remove dead rawPhenotypes binding on CVDI Phenotype page

### DIFF
--- a/src/views/CVDI_Pigean/Gene/Template.vue
+++ b/src/views/CVDI_Pigean/Gene/Template.vue
@@ -4,7 +4,6 @@
         <page-header
             :disease-group="$parent.diseaseGroup"
             :front-contents="$parent.frontContents"
-            :raw-phenotypes="$parent.rawPhenotypes"
         >
         </page-header>
         <!-- warning in case gene name isn't valid -->

--- a/src/views/CVDI_Pigean/GeneSet/Template.vue
+++ b/src/views/CVDI_Pigean/GeneSet/Template.vue
@@ -4,7 +4,6 @@
         <page-header
             :disease-group="$parent.diseaseGroup"
             :front-contents="$parent.frontContents"
-            :raw-phenotypes="$parent.rawPhenotypes"
         >
         </page-header>
 

--- a/src/views/CVDI_Pigean/Phenotype/Template.vue
+++ b/src/views/CVDI_Pigean/Phenotype/Template.vue
@@ -4,7 +4,6 @@
         <page-header
             :disease-group="$parent.diseaseGroup"
             :front-contents="$parent.frontContents"
-            :raw-phenotypes="$parent.rawPhenotypes"
         ></page-header>
 
         <!-- Body -->

--- a/src/views/CVDI_Pigean/Phenotype/main.js
+++ b/src/views/CVDI_Pigean/Phenotype/main.js
@@ -199,9 +199,6 @@ new Vue({
                     name: p.phenotype,
                     display_group: p.group }));
         },
-        rawPhenotypes() {
-            return this.$store.state.bioPortal.phenotypes;
-        },
         utilsBox() {
             let utils = {
                 Formatters: Formatters,


### PR DESCRIPTION
## Summary
Follow-up cleanup to #1109.

That PR stopped dispatching `bioPortal/getPhenotypes` on the CVDI Phenotype page ("removing extraneous bioportal phenotype calls"), but the page still exposed:

```js
rawPhenotypes() { return this.$store.state.bioPortal.phenotypes; }
```

which flowed through `Template.vue` → `PageHeader` → `<disease-systems :phenotypes="rawPhenotypes">`. With the dispatch gone, that header phenotype browser silently received an empty list.

On this page phenotypes come from the pigean phecode map, not the bioPortal list, so the bioPortal feed is genuinely unused here. This removes the dead `rawPhenotypes` computed and its `:raw-phenotypes` binding.

## Safety
- `PageHeader.rawPhenotypes` is defined with `type: Array, default: () => []`, so the prop falls back to an empty array when unbound — same value the widget was already getting.
- No other references to `rawPhenotypes` / `raw-phenotypes` remain on the CVDI Phenotype page.

## Test plan
- [ ] Load the CVDI Pigean Phenotype page; confirm header renders with no console warnings.
- [ ] Confirm the disease-systems header widget behaves as before (it was already receiving an empty phenotype list post-#1109).