### PR TITLE
chore(agents): sync dig-dug-portal/cfde-liver-main v1.0.14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED. Do not edit. -->
-<!-- Version: 1.0.13 | Generated: 2026-06-06T15:26:15Z | Hash: 4a8c28255eea -->
+<!-- Version: 1.0.14 | Generated: 2026-07-29T22:03:53Z | Hash: e94f80d637b3 -->
 <!-- Sources: dig-dug-portal/cfde-liver-main/AGENTS.md + dig-dug-portal/AGENTS.md -->
 
 # dig-dug-portal — cfde-liver-main
@@ -197,6 +197,8 @@ npm install
 ```
 
 On Windows, `npm install --no-optional` reduces optional macOS dependency warnings.
+
+A committed `package-lock.json` pins the dependency tree, so for a clean/reproducible install prefer `npm ci`. Installs resolve cleanly with no extra flags: `eslint` is pinned to `8.57.1`, the version every eslint plugin/config in `devDependencies` accepts (eslint-config-standard requires `^8.0.1`; the import/promise/vue plugins cap at 8). Without that explicit pin, npm auto-resolved eslint to its latest major via the plugins' open-ended `>=7` peers, which the capped plugins rejected — the `ERESOLVE` failure that previously forced `--legacy-peer-deps`.
 
 ### 2. Prototype (Watch Mode)
 


### PR DESCRIPTION
Automated AGENTS sync from [dig-agents-files](https://github.com/broadinstitute/dig-agents-files).

- Source entry: `dig-dug-portal/cfde-liver-main`
- Version: `1.0.14`
- Hash: `e94f80d637b3db48f2938c3ecfcacfb69acd484ea5fb9a174e9919233766c875`
- Source path: `dist/dig-dug-portal/cfde-liver-main/AGENTS.md`

This PR updates `AGENTS.md` only.