### PR TITLE
chore(agents): sync dig-dug-portal/radiant-main v1.0.14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- AUTO-GENERATED. Do not edit. -->
-<!-- Version: 1.0.13 | Generated: 2026-06-06T15:26:15Z | Hash: 51fb1a9929a6 -->
+<!-- Version: 1.0.14 | Generated: 2026-07-29T22:03:53Z | Hash: d05956575090 -->
 <!-- Sources: dig-dug-portal/radiant-main/AGENTS.md + dig-dug-portal/AGENTS.md -->
 
 # dig-dug-portal — radiant-main
@@ -199,6 +199,8 @@ npm install
 ```
 
 On Windows, `npm install --no-optional` reduces optional macOS dependency warnings.
+
+A committed `package-lock.json` pins the dependency tree, so for a clean/reproducible install prefer `npm ci`. Installs resolve cleanly with no extra flags: `eslint` is pinned to `8.57.1`, the version every eslint plugin/config in `devDependencies` accepts (eslint-config-standard requires `^8.0.1`; the import/promise/vue plugins cap at 8). Without that explicit pin, npm auto-resolved eslint to its latest major via the plugins' open-ended `>=7` peers, which the capped plugins rejected — the `ERESOLVE` failure that previously forced `--legacy-peer-deps`.
 
 ### 2. Prototype (Watch Mode)
 


### PR DESCRIPTION
Automated AGENTS sync from [dig-agents-files](https://github.com/broadinstitute/dig-agents-files).

- Source entry: `dig-dug-portal/radiant-main`
- Version: `1.0.14`
- Hash: `d059565750907962ca6e48cd849621848610f56449eb22ff6f97da4132ba3046`
- Source path: `dist/dig-dug-portal/radiant-main/AGENTS.md`

This PR updates `AGENTS.md` only.